### PR TITLE
Fixed image loading when XBMC has Basic Authentication set.

### DIFF
--- a/app/src/main/java/org/xbmc/android/app/manager/HostManager.java
+++ b/app/src/main/java/org/xbmc/android/app/manager/HostManager.java
@@ -153,4 +153,15 @@ public class HostManager {
 		return host == null ? null : host.getUri();
 	}
 
+	/**
+	 * Returns the URI of the active host without trailing slash, with optional credentials (user info).
+	 * If no credentials present, returns the URI without them
+	 * @param includeUserInfo Whether to include credentials in the URI
+	 * @return URI, e.g "http://user:pass@127.0.0.1:8080".
+	 */
+	public String getActiveUri(boolean includeUserInfo) {
+		final XBMCHost host = getActiveHost();
+		return host == null ? null : host.getUri(includeUserInfo);
+	}
+
 }

--- a/app/src/main/java/org/xbmc/android/app/manager/ImageManager.java
+++ b/app/src/main/java/org/xbmc/android/app/manager/ImageManager.java
@@ -17,16 +17,18 @@ public class ImageManager {
 	@Inject protected HostManager hostManager;
 	@Inject protected EventBus bus;
 
-	private String host;
+	private String hostUri, hostUriWithUserInfo;
 
 	public ImageManager() {
 		Injector.inject(this);
 		bus.register(this);
-		host = hostManager.getActiveUri();
+		hostUri = hostManager.getActiveUri();
+		hostUriWithUserInfo = hostManager.getActiveUri(true);
 	}
 
 	public void onEvent(HostSwitched event) {
-		host = event.getHost().getUri();
+		hostUri = event.getHost().getUri();
+		hostUriWithUserInfo = event.getHost().getUri(true);
 	}
 
 	/**
@@ -36,12 +38,28 @@ public class ImageManager {
 	 * @return Image URL
 	 */
 	public String getUrl(Cursor cursor, int field) {
+		return getUrl(cursor, field, hostUri);
+	}
+
+	/**
+	 * Returns the absolute URL of an image, including the user credentials if requested.
+	 * @param cursor Database row
+	 * @param field Field name containing image url
+	 * @param cursor Database row
+	 * @param includeUserInfo Whether to include credentials in the URI
+	 * @return Image URL
+	 */
+	public String getUrl(Cursor cursor, int field, boolean includeUserInfo) {
+		return getUrl(cursor, field, includeUserInfo? hostUriWithUserInfo : hostUri);
+	}
+
+	private String getUrl(Cursor cursor, int field, String hostUri) {
 		try {
 			final String fieldValue = cursor.getString(field);
 			if (fieldValue == null) {
 				return null;
 			}
-			return host + "/image/" + URLEncoder.encode(fieldValue, "UTF-8");
+			return hostUri + "/image/" + URLEncoder.encode(fieldValue, "UTF-8");
 		} catch (UnsupportedEncodingException e) {
 			return null;
 		}

--- a/app/src/main/java/org/xbmc/android/app/ui/ImageViewActivity.java
+++ b/app/src/main/java/org/xbmc/android/app/ui/ImageViewActivity.java
@@ -22,17 +22,24 @@ package org.xbmc.android.app.ui;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.util.Log;
+
 import butterknife.ButterKnife;
 import butterknife.InjectView;
 import com.bumptech.glide.Glide;
 import it.sephiroth.android.library.imagezoom.ImageViewTouch;
 import org.xbmc.android.remotesandbox.R;
+import org.xbmc.android.util.VolleyBasicAuthUrlLoader;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * @author freezy <freezy@xbmc.org>
  */
 public class ImageViewActivity extends Activity {
 
+	private static final String TAG = ImageViewActivity.class.getSimpleName();
 	public final static String EXTRA_URL = "org.xbmc.android.app.EXTRA_URL";
 
 	@InjectView(R.id.image)	ImageViewTouch imageViewTouch;
@@ -46,10 +53,15 @@ public class ImageViewActivity extends Activity {
 
 		final String url = getIntent().getExtras().getString(EXTRA_URL);
 
-		Glide.load(url)
-			.asIs()
-			.fitCenter()
-			.animate(android.R.anim.fade_in)
-			.into(imageViewTouch);
+		try {
+			Glide.using(new VolleyBasicAuthUrlLoader.Factory())
+				.load(new URL(url))
+				.asIs()
+				.fitCenter()
+				.animate(android.R.anim.fade_in)
+				.into(imageViewTouch);
+		} catch (MalformedURLException e) {
+			Log.e(TAG, e.toString());
+		}
 	}
 }

--- a/app/src/main/java/org/xbmc/android/app/ui/MovieActivity.java
+++ b/app/src/main/java/org/xbmc/android/app/ui/MovieActivity.java
@@ -32,8 +32,12 @@ import org.xbmc.android.app.provider.VideoDatabase;
 import org.xbmc.android.app.ui.view.CardView;
 import org.xbmc.android.app.ui.view.ExpandableHeightGridView;
 import org.xbmc.android.remotesandbox.R;
+import org.xbmc.android.util.VolleyBasicAuthUrlLoader;
 
 import javax.inject.Inject;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.text.DecimalFormat;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -146,16 +150,22 @@ public class MovieActivity extends BaseActivity implements LoaderManager.LoaderC
 		titleView.setText(title + (year != null ? " (" + year + ")" : ""));
 		setTitle(title);
 
-		// load poster
-		Glide.load(imageManager.getUrl(data, MoviesQuery.THUMBNAIL))
+		try {
+			// load poster
+			Glide.using(new VolleyBasicAuthUrlLoader.Factory())
+				.load(new URL(imageManager.getUrl(data, MoviesQuery.THUMBNAIL, true)))
 				.centerCrop()
 				.animate(android.R.anim.fade_in)
 				.into(posterView);
 
-		// load fanart
-		Glide.load(imageManager.getUrl(data, MoviesQuery.FANART))
+			// load fanart
+			Glide.using(new VolleyBasicAuthUrlLoader.Factory())
+				.load(new URL(imageManager.getUrl(data, MoviesQuery.FANART, true)))
 				.animate(android.R.anim.fade_in)
 				.into(fanartView);
+		} catch (MalformedURLException e) {
+			Log.e(TAG, e.toString());
+		}
 
 		ratingView.setText(String.valueOf(rating));
 		ratingStarsView.setText(iconManager.getStars(rating));
@@ -169,7 +179,7 @@ public class MovieActivity extends BaseActivity implements LoaderManager.LoaderC
 			@Override
 			public void onClick(View v) {
 				final Intent intent = new Intent(MovieActivity.this, ImageViewActivity.class);
-				intent.putExtra(ImageViewActivity.EXTRA_URL, imageManager.getUrl(data, MoviesQuery.THUMBNAIL));
+				intent.putExtra(ImageViewActivity.EXTRA_URL, imageManager.getUrl(data, MoviesQuery.THUMBNAIL, true));
 				startActivity(intent);
 			}
 		});
@@ -248,12 +258,17 @@ public class MovieActivity extends BaseActivity implements LoaderManager.LoaderC
 			final ImageView shotView = (ImageView) view.findViewById(R.id.shot);
 
 			// load image
-			final String imgUrl = imageManager.getUrl(cursor, CastQuery.THUMBNAIL);
+			final String imgUrl = imageManager.getUrl(cursor, CastQuery.THUMBNAIL, true);
 			if (imgUrl != null) {
-				Glide.load(imgUrl)
-					.centerCrop()
-					.animate(android.R.anim.fade_in)
-					.into(shotView);
+				try {
+					Glide.using(new VolleyBasicAuthUrlLoader.Factory())
+						.load(new URL(imgUrl))
+						.centerCrop()
+						.animate(android.R.anim.fade_in)
+						.into(shotView);
+				} catch (MalformedURLException e) {
+					Log.e(TAG, e.toString());
+				}
 			}
 
 			// set data
@@ -333,13 +348,13 @@ public class MovieActivity extends BaseActivity implements LoaderManager.LoaderC
 		final int ROLE = 3;
 	}
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                finish();
-            default:
-                return super.onOptionsItemSelected(item);
-        }
-    }
+	@Override
+	public boolean onOptionsItemSelected(MenuItem item) {
+		switch (item.getItemId()) {
+			case android.R.id.home:
+				finish();
+			default:
+				return super.onOptionsItemSelected(item);
+		}
+	}
 }

--- a/app/src/main/java/org/xbmc/android/app/ui/fragment/AlbumCompactFragment.java
+++ b/app/src/main/java/org/xbmc/android/app/ui/fragment/AlbumCompactFragment.java
@@ -44,9 +44,12 @@ import org.xbmc.android.app.manager.HostManager;
 import org.xbmc.android.app.provider.AudioContract;
 import org.xbmc.android.app.provider.AudioDatabase;
 import org.xbmc.android.remotesandbox.R;
+import org.xbmc.android.util.VolleyBasicAuthUrlLoader;
 
 import javax.inject.Inject;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.URLEncoder;
 
 /**
@@ -74,7 +77,7 @@ public class AlbumCompactFragment extends GridFragment implements LoaderManager.
 		super.onCreate(savedInstanceState);
 		Injector.inject(this);
 		bus.register(this);
-		hostUri = hostManager.getActiveUri();
+		hostUri = hostManager.getActiveUri(true);
 	}
 
 	@Override
@@ -116,7 +119,7 @@ public class AlbumCompactFragment extends GridFragment implements LoaderManager.
 	 * @param event Event data
 	 */
 	public void onEvent(HostSwitched event) {
-		hostUri = event.getHost().getUri();
+		hostUri = event.getHost().getUri(true);
 		getLoaderManager().restartLoader(0, null, this);
 	}
 
@@ -163,12 +166,15 @@ public class AlbumCompactFragment extends GridFragment implements LoaderManager.
 			final TextView subtitleView = (TextView) view.findViewById(R.id.artist);
 			final ImageView imageView = (ImageView) view.findViewById(R.id.list_album_cover);
 			try {
-				final String url = hostUri + "/image/" + URLEncoder.encode(cursor.getString(AlbumsQuery.THUMBNAIL), "UTF-8");
-				Glide.load(url)
+				final URL url = new URL(hostUri + "/image/" + URLEncoder.encode(cursor.getString(AlbumsQuery.THUMBNAIL), "UTF-8"));
+				Glide.using(new VolleyBasicAuthUrlLoader.Factory())
+					.load(url)
 					.centerCrop()
 					.animate(android.R.anim.fade_in)
 					.into(imageView);
 
+			} catch (MalformedURLException e) {
+				Log.e(TAG, e.toString());
 			} catch (UnsupportedEncodingException e) {
 				Log.e(TAG, "Cannot encode " + cursor.getString(AlbumsQuery.THUMBNAIL) + " from UTF-8.");
 			}

--- a/app/src/main/java/org/xbmc/android/app/ui/fragment/MovieCompactFragment.java
+++ b/app/src/main/java/org/xbmc/android/app/ui/fragment/MovieCompactFragment.java
@@ -51,9 +51,12 @@ import org.xbmc.android.app.ui.MovieActivity;
 import org.xbmc.android.app.ui.MoviesActivity;
 import org.xbmc.android.app.ui.view.CardView;
 import org.xbmc.android.remotesandbox.R;
+import org.xbmc.android.util.VolleyBasicAuthUrlLoader;
 
 import javax.inject.Inject;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.URLEncoder;
 
 import static org.xbmc.android.app.ui.fragment.MovieListFragment.DataHolder;
@@ -97,7 +100,7 @@ public class MovieCompactFragment extends GridFragment implements LoaderManager.
 		super.onCreate(savedInstanceState);
 		Injector.inject(this);
 		bus.register(this);
-		hostUri = hostManager.getActiveUri();
+		hostUri = hostManager.getActiveUri(true);
 	}
 
 	@Override
@@ -151,7 +154,7 @@ public class MovieCompactFragment extends GridFragment implements LoaderManager.
 	 * @param event Event data
 	 */
 	public void onEvent(HostSwitched event) {
-		hostUri = event.getHost().getUri();
+		hostUri = event.getHost().getUri(true);
 		getLoaderManager().restartLoader(0, null, this);
 	}
 
@@ -220,12 +223,15 @@ public class MovieCompactFragment extends GridFragment implements LoaderManager.
 
 			// load image
 			try {
-				final String url = hostUri + "/image/" + URLEncoder.encode(cursor.getString(MoviesQuery.THUMBNAIL), "UTF-8");
-				Glide.load(url)
-						.centerCrop()
-						.animate(android.R.anim.fade_in)
-						.into(viewHolder.imageView);
+				final URL url = new URL(hostUri + "/image/" + URLEncoder.encode(cursor.getString(MoviesQuery.THUMBNAIL), "UTF-8"));
+				Glide.using(new VolleyBasicAuthUrlLoader.Factory())
+					.load(url)
+					.centerCrop()
+					.animate(android.R.anim.fade_in)
+					.into(viewHolder.imageView);
 
+			} catch (MalformedURLException e) {
+				Log.e(TAG, e.toString());
 			} catch (UnsupportedEncodingException e) {
 				Log.e(TAG, "Cannot encode " + cursor.getString(MoviesQuery.THUMBNAIL) + " from UTF-8.");
 			}

--- a/app/src/main/java/org/xbmc/android/app/ui/fragment/MovieListFragment.java
+++ b/app/src/main/java/org/xbmc/android/app/ui/fragment/MovieListFragment.java
@@ -32,9 +32,12 @@ import org.xbmc.android.app.provider.VideoDatabase;
 import org.xbmc.android.app.ui.MovieActivity;
 import org.xbmc.android.app.ui.view.CardView;
 import org.xbmc.android.remotesandbox.R;
+import org.xbmc.android.util.VolleyBasicAuthUrlLoader;
 
 import javax.inject.Inject;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.URLEncoder;
 
 /**
@@ -80,7 +83,7 @@ public class MovieListFragment extends GridFragment implements LoaderManager.Loa
 		Injector.inject(this);
 		bus.register(this);
 
-		hostUri = hostManager.getActiveUri();
+		hostUri = hostManager.getActiveUri(true);
 		adapter = new MoviesAdapter(getActivity());
 
 		setGridAdapter(adapter);
@@ -109,7 +112,7 @@ public class MovieListFragment extends GridFragment implements LoaderManager.Loa
 	 * @param event Event data
 	 */
 	public void onEvent(HostSwitched event) {
-		hostUri = event.getHost().getUri();
+		hostUri = event.getHost().getUri(true);
 		getLoaderManager().restartLoader(0, null, this);
 	}
 
@@ -191,12 +194,15 @@ public class MovieListFragment extends GridFragment implements LoaderManager.Loa
 
 			// load image
 			try {
-				final String url = hostUri + "/image/" + URLEncoder.encode(cursor.getString(MoviesQuery.THUMBNAIL), "UTF-8");
-				Glide.load(url)
+				final URL url = new URL(hostUri + "/image/" + URLEncoder.encode(cursor.getString(MoviesQuery.THUMBNAIL), "UTF-8"));
+				Glide.using(new VolleyBasicAuthUrlLoader.Factory())
+					.load(url)
 					.centerCrop()
 					.animate(android.R.anim.fade_in)
 					.into(viewHolder.imageView);
 
+			} catch (MalformedURLException e) {
+				Log.e(TAG, e.toString());
 			} catch (UnsupportedEncodingException e) {
 				Log.e(TAG, "Cannot encode " + cursor.getString(MoviesQuery.THUMBNAIL) + " from UTF-8.");
 			}

--- a/app/src/main/java/org/xbmc/android/util/VolleyBasicAuthStreamLoader.java
+++ b/app/src/main/java/org/xbmc/android/util/VolleyBasicAuthStreamLoader.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2005-2014 Team XBMC
+ *     http://xbmc.org
+ *
+ * This Program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This Program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with XBMC Remote; see the file license.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+package org.xbmc.android.util;
+
+import android.util.Base64;
+
+import com.android.volley.AuthFailureError;
+import com.android.volley.DefaultRetryPolicy;
+import com.android.volley.NetworkResponse;
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.Response;
+import com.android.volley.RetryPolicy;
+import com.android.volley.VolleyError;
+import com.bumptech.glide.loader.stream.StreamLoader;
+
+import java.io.ByteArrayInputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Custom StreamLoader using Volley for fetching images via http, with basic authentication
+ *
+ * This is basically a copy of VolleyStreamLoader present in the Glide library, which couldn't be
+ * extended because it has private members, which we'll need to access
+ *
+ * @author Synced <synced.synapse@gmail.com>
+ */
+public class VolleyBasicAuthStreamLoader implements StreamLoader {
+	private final RequestQueue requestQueue;
+	private final URL url;
+	private final RetryPolicy retryPolicy;
+	private Request current = null;
+
+	@SuppressWarnings("unused")
+	public VolleyBasicAuthStreamLoader(RequestQueue requestQueue, URL url) {
+		this(requestQueue, url, new DefaultRetryPolicy());
+	}
+
+	public VolleyBasicAuthStreamLoader(RequestQueue requestQueue, URL url, RetryPolicy retryPolicy) {
+		this.requestQueue = requestQueue;
+		this.url = url;
+		this.retryPolicy = retryPolicy;
+	}
+
+	@Override
+	public void loadStream(final StreamReadyCallback cb) {
+		Request<Void> request = new BasicAuthRequest(url, cb);
+		request.setRetryPolicy(retryPolicy);
+		current = requestQueue.add(request);
+	}
+
+	@Override
+	public void cancel() {
+		final Request local = current;
+		if (local != null) {
+			local.cancel();
+			current = null;
+		}
+	}
+
+	private static class BasicAuthRequest extends Request<Void> {
+		private final StreamReadyCallback cb;
+		private final URL url;
+
+		public BasicAuthRequest(URL url, final StreamReadyCallback cb) {
+			super(Method.GET, url.toString(), new Response.ErrorListener() {
+				@Override
+				public void onErrorResponse(VolleyError error) {
+					cb.onException(error);
+				}
+			});
+			this.cb = cb;
+			this.url = url;
+		}
+
+		@Override
+		protected Response<Void> parseNetworkResponse(NetworkResponse response) {
+			cb.onStreamReady(new ByteArrayInputStream(response.data));
+			return Response.success(null, getCacheEntry());
+		}
+
+		@Override
+		protected void deliverResponse(Void response) { }
+
+		@Override
+		public Map<String, String> getHeaders() throws AuthFailureError {
+			Map<String, String> params = new HashMap<String, String>();
+			String creds = url.getUserInfo();
+			if ((creds != null) && !creds.isEmpty()) {
+				String auth = "Basic " + Base64.encodeToString(creds.getBytes(), Base64.DEFAULT);
+				params.put("Authorization", auth);
+			}
+			return params;
+		}
+	}
+}

--- a/app/src/main/java/org/xbmc/android/util/VolleyBasicAuthUrlLoader.java
+++ b/app/src/main/java/org/xbmc/android/util/VolleyBasicAuthUrlLoader.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2005-2014 Team XBMC
+ *     http://xbmc.org
+ *
+ * This Program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This Program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with XBMC Remote; see the file license.  If not, write to
+ * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+package org.xbmc.android.util;
+
+import android.content.Context;
+import com.android.volley.DefaultRetryPolicy;
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.RetryPolicy;
+import com.android.volley.toolbox.Volley;
+import com.bumptech.glide.loader.model.GenericLoaderFactory;
+import com.bumptech.glide.loader.model.ModelLoader;
+import com.bumptech.glide.loader.model.ModelLoaderFactory;
+import com.bumptech.glide.loader.stream.StreamLoader;
+
+import java.net.URL;
+
+
+/**
+ * Custom ModelLoader using Volley with basic authentication
+ *
+ * This is basically a copy of VolleyUrlLoader present in the Glide library, which couldn't be
+ * extended because it has the requestQueue as a private member, and we'll need access to it to
+ * pass it to the StreamLoader.
+ *
+ * This just serves to create the VolleyBasicAuthStreamLoader where the basic authentication
+ * is implemented.
+ *
+ * @author Synced <synced.synapse@gmail.com>
+ */
+public class VolleyBasicAuthUrlLoader implements ModelLoader<URL> {
+	public static class Factory implements ModelLoaderFactory<URL> {
+		private RequestQueue requestQueue;
+
+		public Factory() { }
+
+		public Factory(RequestQueue requestQueue) {
+			this.requestQueue = requestQueue;
+		}
+
+		protected RequestQueue getRequestQueue(Context context) {
+			if (requestQueue == null) {
+				requestQueue = Volley.newRequestQueue(context);
+			}
+			return requestQueue;
+		}
+
+		@Override
+		public ModelLoader<URL> build(Context context, GenericLoaderFactory factories) {
+			return new VolleyBasicAuthUrlLoader(getRequestQueue(context));
+		}
+
+		@Override
+		public Class<? extends ModelLoader<URL>> loaderClass() {
+			return VolleyBasicAuthUrlLoader.class;
+		}
+
+		@Override
+		public void teardown() {
+			if (requestQueue != null) {
+				requestQueue.stop();
+				requestQueue.cancelAll(new RequestQueue.RequestFilter() {
+					@Override
+					public boolean apply(Request<?> request) {
+						return true;
+					}
+				});
+				requestQueue = null;
+			}
+		}
+	}
+
+	private final RequestQueue requestQueue;
+
+	public VolleyBasicAuthUrlLoader(RequestQueue requestQueue) {
+		this.requestQueue = requestQueue;
+	}
+
+	@Override
+	public StreamLoader getStreamLoader(URL url, int width, int height) {
+		return new VolleyBasicAuthStreamLoader(requestQueue, url, getRetryPolicy());
+	}
+
+	@Override
+	public String getId(URL url) {
+		return url.toString();
+	}
+
+	protected RetryPolicy getRetryPolicy() {
+		return new DefaultRetryPolicy();
+	}
+}

--- a/app/src/main/java/org/xbmc/android/zeroconf/XBMCHost.java
+++ b/app/src/main/java/org/xbmc/android/zeroconf/XBMCHost.java
@@ -91,6 +91,19 @@ public class XBMCHost implements Parcelable {
 		return "http://" + address + ":" + port;
 	}
 
+	/**
+	 * Returns the URI of the host without trailing slash, with optional credentials (user info).
+	 * If no credentials present, returns the URI without them
+	 * @param includeUserInfo Whether to include credentials in the URI
+	 * @return URI, e.g "http://user:pass@127.0.0.1:8080".
+	 */
+	public String getUri(boolean includeUserInfo) {
+		return (includeUserInfo &&
+			username != null && !username.isEmpty() && password != null && !password.isEmpty()) ?
+			"http://" + username + ":" + password + "@" + address + ":" + port:
+			getUri();
+	}
+
 	public void setActive(boolean active) {
 		this.active = active;
 	}


### PR DESCRIPTION
This fixes [Issue #20](https://github.com/freezy/android-xbmcremote-sandbox/issues/20).

Problem is Glide doesn't have an option to fetch images with Basic Authentication enabled, and while theoretically just specifying the url with ```http://user:password@host:port``` should work, i still kept receiving 401s.

To solve this, the following changes were made:
* The URLs for fetching images are of the form ```http://user:password@host:port```
* All class to Glide are made using a custom ModelLoader and StreamLoader (VolleyBasicAuthModelLoader and VolleyBasicAuthStreamLoader), which set the HTTP authorization header based on what's present on the URL to load. These classes are essentially the same that are present in Glide (VolleyUrlModelLoader and VolleyUrlStreamLoader), with the added GetHeaders override. I couldn't subclass the existing ones because some necessary members of those classes are private.

Please review this, and check if you find it acceptable.

Some other notes:
* I stashed the ModelLoader and StreamLoader classes under org.xbmc.android.util. If you would like for them to be in other place, let me know.
* I changed the getUri/getActiveIri members in XBMCHost and HostManager to accept a boolean specifying whether to return the "simple" URL or the URL with the user credentials. This seemed like the simplest thing to do, but if you don't like it i can do it some other way.