### PR TITLE
Updated gradle and dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,14 +2,14 @@ apply plugin: 'com.android.application'
 
 android {
 
-	compileSdkVersion 21
-	buildToolsVersion "21.1.2"
+	compileSdkVersion 22
+	buildToolsVersion "22.0.1"
 
 	defaultConfig {
 		applicationId "tv.kodi.android.app"
 
 		minSdkVersion 15
-		targetSdkVersion 21
+		targetSdkVersion 22
 
 		versionCode 1
 		versionName "0.0.1-SNAPSHOT"
@@ -36,28 +36,17 @@ android {
 	}
 }
 
-
-
-apply plugin: 'android-unit-test'
-
-androidUnitTest {
-	downloadDependenciesSources true
-	downloadDependenciesJavadoc true
-	downloadTestDependenciesSources true
-	downloadTestDependenciesJavadoc true
-}
-
 dependencies {
 
 	// app
-	compile 'com.android.support:support-annotations:21.0.3'
-	compile 'com.android.support:support-v4:21.0.3'
-	compile 'com.android.support:appcompat-v7:21.0.3'
+	compile 'com.android.support:support-annotations:22.2.1'
+	compile 'com.android.support:support-v4:22.2.1'
+	compile 'com.android.support:appcompat-v7:22.2.1'
 	compile('com.google.android.gms:play-services:6.1.+') {
 		exclude module: 'support-v4'
 	}
-	compile 'com.squareup.dagger:dagger:1.0.1'
-	compile 'com.squareup.dagger:dagger-compiler:1.0.1'
+	compile 'com.squareup.dagger:dagger:1.2.2'
+	compile 'com.squareup.dagger:dagger-compiler:1.2.2'
 	compile 'com.jakewharton:butterknife:4.0.1'
 	compile 'de.greenrobot:eventbus:2.2.0'
 	compile 'com.github.chrisbanes.actionbarpulltorefresh:extra-abc:+'
@@ -79,7 +68,10 @@ dependencies {
 	androidTestCompile 'org.hamcrest:hamcrest-core:1.1'
 	androidTestCompile 'org.hamcrest:hamcrest-library:1.1'
 	androidTestCompile 'org.hamcrest:hamcrest-integration:1.1'
-	androidTestCompile 'com.android.support.test.espresso:espresso-core:2.0'
+	androidTestCompile('com.android.support.test.espresso:espresso-core:2.2'){
+		exclude group: 'com.squareup', module: 'javawriter'
+		exclude group: 'com.android.support', module: 'support-annotations'
+	}
 	androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 	}
 
 	dependencies {
-		classpath 'com.android.tools.build:gradle:1.0.0'
+		classpath 'com.android.tools.build:gradle:1.2.3'
 		classpath 'com.github.jcandksolutions.gradle:android-unit-test:2.0.2'
 	}
 }


### PR DESCRIPTION
Did an update to the newest version of Gradle.

By this I realized, https://github.com/JCAndKSolutions/android-unit-test is deprecated and not used anymore, therefor removed from build.gradle

Furthermore there were some issues with conflicting dependencies between app and test compile. Though I'm wondering, does this project use unit testing?

Yours
Graphity
